### PR TITLE
Enhance compatibility to Magento v1.4.0.2

### DIFF
--- a/src/app/code/community/FireGento/Debug/Block/Diagnostic/CheckSystem.php
+++ b/src/app/code/community/FireGento/Debug/Block/Diagnostic/CheckSystem.php
@@ -63,8 +63,12 @@ class FireGento_Debug_Block_Diagnostic_CheckSystem
         /*
          * MAGENTO
          */
+        $edition = '-';
+        if (method_exists(Mage, 'getEdition')) {
+            $edition = Mage::getEdition();
+        }
         $magento = array(
-            'edition' => Mage::getEdition(),
+            'edition' => $edition,
             'version' => Mage::getVersion(),
             'developer_mode' => Mage::getIsDeveloperMode(),
             'secret_key' => Mage::getStoreConfigFlag('admin/security/use_form_key'),


### PR DESCRIPTION
I know this module is only supported from 1.5.0.0 onwards. But it works quite well except for the "Check System" page where a fatal PHP error occurs since the method `getEdition` is not available:

```
Fatal error: Call to undefined method Mage::getEdition() in /path/to/magento/app/code/community/FireGento/Debug/Block/Diagnostic/CheckSystem.php on line 67
```

There are probably some ways of determining the correct edition by looking at some files but in order to render the page this fix should do the trick just nicely.
