### PR TITLE
Changed admin routing

### DIFF
--- a/src/app/code/community/FireGento/Debug/controllers/DiagnosticController.php
+++ b/src/app/code/community/FireGento/Debug/controllers/DiagnosticController.php
@@ -136,4 +136,14 @@ class FireGento_Debug_DiagnosticController
         $this->_title($this->__('phpinfo') . ' / '. 'FIREGENTO');
         $this->renderLayout();
     }
+
+    /**
+     * ACL checking
+     *
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('firegento/diagnostic');
+    }
 }

--- a/src/app/code/community/FireGento/Debug/controllers/IndexController.php
+++ b/src/app/code/community/FireGento/Debug/controllers/IndexController.php
@@ -44,4 +44,14 @@ class FireGento_Debug_IndexController
         $this->_title($this->__('About FireGento') . ' / '. 'FIREGENTO');
         $this->renderLayout();
     }
+
+    /**
+     * ACL checking
+     *
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('firegento/firegento_about');
+    }
 }

--- a/src/app/code/community/FireGento/Debug/controllers/LogController.php
+++ b/src/app/code/community/FireGento/Debug/controllers/LogController.php
@@ -111,4 +111,14 @@ class FireGento_Debug_LogController extends Mage_Adminhtml_Controller_Action
         );
         Mage::log($array);
     }
+
+    /**
+     * ACL checking
+     *
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('firegento/logs');
+    }
 }

--- a/src/app/code/community/FireGento/Debug/etc/adminhtml.xml
+++ b/src/app/code/community/FireGento/Debug/etc/adminhtml.xml
@@ -28,39 +28,39 @@
 					<children>
 						<check_modules translate="title" module="firegento">
 							<title>Check Modules</title>
-							<action>firegento/diagnostic/checkModules</action>
+							<action>adminhtml/diagnostic/checkModules</action>
 							<sort_order>10</sort_order>
 						</check_modules>
 						<check_rewrites translate="title" module="firegento">
 							<title>Check Rewrites</title>
-							<action>firegento/diagnostic/checkRewrites</action>
+							<action>adminhtml/diagnostic/checkRewrites</action>
 							<sort_order>20</sort_order>
 						</check_rewrites>
 						<check_events translate="title" module="firegento">
 							<title>Check Events</title>
-							<action>firegento/diagnostic/checkEvents</action>
+							<action>adminhtml/diagnostic/checkEvents</action>
 							<sort_order>30</sort_order>
 						</check_events>
 						<check_system translate="title" module="firegento">
 							<title>Check System</title>
-							<action>firegento/diagnostic/checkSystem</action>
+							<action>adminhtml/diagnostic/checkSystem</action>
 							<sort_order>40</sort_order>
 						</check_system>
 						<phpinfo translate="title" module="firegento">
 							<title>phpinfo()</title>
-							<action>firegento/diagnostic/phpinfo</action>
+							<action>adminhtml/diagnostic/phpinfo</action>
 							<sort_order>50</sort_order>
 						</phpinfo>
 					</children>
 				</diagnostic>
 				<logs>
 					<title>Logs</title>
-					<action>firegento/log/index</action>
+					<action>adminhtml/log/index</action>
 					<sort_order>20</sort_order>
 				</logs>
 				<about_firegento translate="title" module="firegento">
 					<title>About FireGento</title>
-					<action>firegento/index/about</action>
+					<action>adminhtml/index/about</action>
 					<sort_order>999</sort_order>
 				</about_firegento>
 				<configuration translate="title" module="firegento">

--- a/src/app/code/community/FireGento/Debug/etc/config.xml
+++ b/src/app/code/community/FireGento/Debug/etc/config.xml
@@ -41,13 +41,13 @@
     </global>
     <admin>
         <routers>
-            <firegento>
-                <use>admin</use>
+            <adminhtml>
                 <args>
-                    <module>FireGento_Debug</module>
-                    <frontName>firegento</frontName>
+                    <modules>
+                        <firegento_debug before="Mage_Adminhtml">FireGento_Debug</firegento_debug>
+                    </modules>
                 </args>
-            </firegento>
+            </adminhtml>
         </routers>
     </admin>
     <adminhtml>

--- a/src/app/code/community/FireGento/Debug/etc/system.xml
+++ b/src/app/code/community/FireGento/Debug/etc/system.xml
@@ -17,7 +17,7 @@
  */
  -->
 <config>
-	<sections>
+    <sections>
         <firegento translate="label" module="firegento">
             <label>FIREGENTO</label>
             <tab>advanced</tab>
@@ -87,5 +87,5 @@
                 </log>
             </groups>
         </firegento>
-	</sections>
+    </sections>
 </config>

--- a/src/app/design/adminhtml/default/default/layout/firegento_debug.xml
+++ b/src/app/design/adminhtml/default/default/layout/firegento_debug.xml
@@ -17,37 +17,37 @@
  */
  -->
 <layout>
-    <firegento_index_about>
+    <adminhtml_index_about>
         <reference name="content">
             <block type="core/template" name="firegento.index.about" template="firegento/debug/index/about.phtml" />
         </reference>
-    </firegento_index_about>
-    <firegento_diagnostic_checkmodules>
+    </adminhtml_index_about>
+    <adminhtml_diagnostic_checkmodules>
         <reference name="content">
             <block type="firegento/diagnostic_checkModules" name="firegento.diagnostic.checkmodules" />
         </reference>
-    </firegento_diagnostic_checkmodules>
-    <firegento_diagnostic_checkrewrites>
+    </adminhtml_diagnostic_checkmodules>
+    <adminhtml_diagnostic_checkrewrites>
         <reference name="content">
             <block type="firegento/diagnostic_checkRewrites" name="firegento.diagnostic.checkrewrites" />
         </reference>
-    </firegento_diagnostic_checkrewrites>
-    <firegento_diagnostic_checkevents>
+    </adminhtml_diagnostic_checkrewrites>
+    <adminhtml_diagnostic_checkevents>
         <reference name="content">
             <block type="firegento/diagnostic_checkEvents" name="firegento.diagnostic.checkevents" />
         </reference>
-    </firegento_diagnostic_checkevents>
-    <firegento_diagnostic_checksystem>
+    </adminhtml_diagnostic_checkevents>
+    <adminhtml_diagnostic_checksystem>
         <reference name="head">
             <action method="addCss"><stylesheet>firegento/debug/styles.css</stylesheet></action>
         </reference>
         <reference name="content">
             <block type="firegento/diagnostic_checkSystem" name="firegento.diagnostic.checksystem" template="firegento/debug/diagnostic/checksystem.phtml" />
         </reference>
-    </firegento_diagnostic_checksystem>
-    <firegento_diagnostic_phpinfo>
+    </adminhtml_diagnostic_checksystem>
+    <adminhtml_diagnostic_phpinfo>
         <reference name="content">
             <block type="firegento/diagnostic_phpinfo" name="firegento.diagnostic.phpinfo" template="firegento/debug/diagnostic/phpinfo.phtml" />
         </reference>
-    </firegento_diagnostic_phpinfo>
+    </adminhtml_diagnostic_phpinfo>
 </layout>


### PR DESCRIPTION
Changed the way this module integrates in the Magento backend due to security changes in Magento 1.9.x.x.

It should be considered to rename some of the controllers since they introduce a rather generic namespace (index), which potentially conflicts with other third-party modules.

[EDIT]
Sorry, I branched off from master instead of develop. But I incorporated all changes from develop as well.  So it should merge nicely.
[/EDIT]
